### PR TITLE
message-service-typeorm-setup/jalg Initial setup for TypeORM.

### DIFF
--- a/message-service/package-lock.json
+++ b/message-service/package-lock.json
@@ -36,6 +36,7 @@
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
+        "@types/pg": "^8.11.0",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -2430,6 +2431,74 @@
       "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-sDAlRiBNthGjNFfvt0k6mtotoVYVQ63pA8R4EMWka7crawSR60waVYR0HAgmPRs/e2YaeJTD/43OoZ3PFw80pw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/qs": {
@@ -7013,6 +7082,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7313,6 +7388,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
@@ -7483,6 +7567,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -11429,6 +11519,61 @@
         "undici-types": "~5.26.4"
       }
     },
+    "@types/pg": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.0.tgz",
+      "integrity": "sha512-sDAlRiBNthGjNFfvt0k6mtotoVYVQ63pA8R4EMWka7crawSR60waVYR0HAgmPRs/e2YaeJTD/43OoZ3PFw80pw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      },
+      "dependencies": {
+        "pg-types": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+          "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+          "dev": true,
+          "requires": {
+            "pg-int8": "1.0.1",
+            "pg-numeric": "1.0.2",
+            "postgres-array": "~3.0.1",
+            "postgres-bytea": "~3.0.0",
+            "postgres-date": "~2.1.0",
+            "postgres-interval": "^3.0.0",
+            "postgres-range": "^1.1.1"
+          }
+        },
+        "postgres-array": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+          "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+          "dev": true
+        },
+        "postgres-bytea": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+          "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+          "dev": true,
+          "requires": {
+            "obuf": "~1.1.2"
+          }
+        },
+        "postgres-date": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+          "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+          "dev": true
+        },
+        "postgres-interval": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+          "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+          "dev": true
+        }
+      }
+    },
     "@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
@@ -14846,6 +14991,12 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
     },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -15065,6 +15216,12 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
+    "pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true
+    },
     "pg-pool": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
@@ -15190,6 +15347,12 @@
       "requires": {
         "xtend": "^4.0.0"
       }
+    },
+    "postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/message-service/package.json
+++ b/message-service/package.json
@@ -52,6 +52,7 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
+    "@types/pg": "^8.11.0",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/message-service/src/database/data-source.ts
+++ b/message-service/src/database/data-source.ts
@@ -1,0 +1,14 @@
+import { DataSource } from "typeorm";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+export const AppDataSource = new DataSource({
+  type: "postgres",
+  url: `postgres://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}:${process.env.DATABASE_PORT}/${process.env.DATABASE_NAME}`,
+  synchronize: false,
+  logging: false,
+  entities: ["src/**/*.entity.ts"],
+  migrations: ["src/database/migrations/*.ts"],
+  migrationsTableName: "migrations",
+});

--- a/message-service/src/database/database.module.ts
+++ b/message-service/src/database/database.module.ts
@@ -1,0 +1,49 @@
+import { Module, Global } from "@nestjs/common";
+import { ConfigType } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Client } from "pg";
+
+import config from "src/config";
+
+@Global()
+@Module({
+  imports: [
+    TypeOrmModule.forRootAsync({
+      inject: [config.KEY],
+      useFactory: (configService: ConfigType<typeof config>) => {
+        const { username, host, name, password, port } = configService.database;
+        return {
+          type: "postgres",
+          host,
+          port: Number(port),
+          username,
+          password,
+          database: name,
+          autoLoadEntities: true,
+          synchronize: false, // DO NOT USE IN PRODUCTION
+          entities: [],
+        };
+      },
+    }),
+  ],
+  providers: [
+    {
+      provide: "PG",
+      useFactory: (configService: ConfigType<typeof config>) => {
+        const { username, host, name, password, port } = configService.database;
+        const client = new Client({
+          host,
+          port: Number(port),
+          user: username,
+          password,
+          database: name,
+        });
+        client.connect();
+        return client;
+      },
+      inject: [config.KEY],
+    },
+  ],
+  exports: ["PG", TypeOrmModule],
+})
+export class DatabaseModule {}


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This is the initial setup for `TypeORM` on the Message Service. Modifications could be added in the following PRs once `pgadmin` has been configured on a `docker-compose.yml` file.

Fixes #(issue)

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Manual Testing
- [ ] Unit test: jest
- [ ] e2e: Supertest

### How to use the feature
A GIF of the feature in action is useful here for larger features, otherwise a description suffices.

These are just config changes. Once `pgadmin` has been properly setup we will be able to test its functionality. Or at least, be able to interact with `pgadmin` on `port:5050`

### Prerequisites
Whether reviewers should add env variables (don't put them in here), run npm install, specific browser requirements, etc.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have linked the relevant issue(s) to this PR
- [ ] All checks pass on CI/CD.
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules