### PR TITLE
message-service-initialMessages/jalg created first draft for initialM…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   message-service:
     build: ./message-service
     env_file:
-      - ./message-service/.env
+      - ./message-service/.env.prod
     ports:
       - "3000:3000"
     networks:

--- a/message-service/.gitignore
+++ b/message-service/.gitignore
@@ -36,6 +36,8 @@ lerna-debug.log*
 
 # Misc
 .env
+.env.prod
+dir.txt
 pgadmin_data
 postgres_data
 

--- a/message-service/docker-compose.yml
+++ b/message-service/docker-compose.yml
@@ -28,18 +28,6 @@ services:
     networks:
       - my_custom_network
 
-  # app:
-  #   volumes:
-  #     - .:/usr/src/app
-  #     - /usr/src/app/node_modules
-  #   build:
-  #     .
-  #   image: jeffersongarcia1599/typeorm-migrations:0.0.1
-  #   depends_on:
-  #     - postgres
-  #   networks:
-  #     - my_custom_network
-
 networks:
   my_custom_network:
     external: true

--- a/message-service/src/app.module.ts
+++ b/message-service/src/app.module.ts
@@ -8,7 +8,7 @@ import { MessagesModule } from "./messages/messages.module";
 import { environments } from "./environments";
 import config from "./config";
 import { DatabaseModule } from "./database/database.module";
-import { GroupsService } from './messages/services/groups/groups.service';
+import { GroupsService } from "./messages/services/groups/groups.service";
 
 @Module({
   imports: [

--- a/message-service/src/database/migrations/1709604331315-initial-migrations.ts
+++ b/message-service/src/database/migrations/1709604331315-initial-migrations.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InitialMigrations1709604331315 implements MigrationInterface {
+  name = "InitialMigrations1709604331315";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "message" DROP COLUMN "ReceiverId"');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "message" ADD "ReceiverId" integer');
+  }
+}

--- a/message-service/src/messages/dtos/message.dto.ts
+++ b/message-service/src/messages/dtos/message.dto.ts
@@ -2,22 +2,13 @@ import { ApiProperty, PartialType } from "@nestjs/swagger";
 import {
   IsDateString,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
+  Min,
 } from "class-validator";
-
-enum MessageStatus {
-  Edited = "edited",
-  Deleted = "deleted",
-}
-
-enum MessageType {
-  Text = "text",
-  Image = "image",
-  Video = "video",
-  Audio = "audio",
-  File = "file",
-}
+import { MessageStatus, MessageType } from "../entities/message.entity";
 
 export class CreateMessageDto {
   @IsString()
@@ -25,18 +16,18 @@ export class CreateMessageDto {
   @ApiProperty({ description: "The content of the message" })
   Content: string;
 
-  @IsString()
-  @IsNotEmpty()
+  @IsNumber()
+  @IsPositive()
   @ApiProperty({ description: "The ID of the sender" })
   SenderId: number;
 
-  @IsString()
-  @IsOptional()
+  @IsNumber()
+  @IsPositive()
   @ApiProperty({ description: "The ID of the receiver" })
   ReceiverId?: number; // Optional, assuming it can be null for group messages
 
-  @IsString()
-  @IsOptional()
+  @IsNumber()
+  @IsPositive()
   @ApiProperty({ description: "The ID of the group" })
   GroupId?: number; // Optional, assuming it can be null for direct messages (DMs)
 
@@ -89,3 +80,43 @@ export class CreateMessageDto {
 }
 
 export class UpdateMessageDto extends PartialType(CreateMessageDto) {}
+
+export class FilterMessagesDto {
+  @IsNumber()
+  @IsPositive()
+  @ApiProperty({
+    description: "The ID of the group",
+    required: false,
+  })
+  GroupId?: number;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    description: "The type of the message",
+    required: false,
+  })
+  Type?: MessageType;
+
+  @IsOptional()
+  @IsNumber({ allowNaN: false }, { message: "The limit must be a number" })
+  @IsPositive()
+  @ApiProperty({ description: "The limit of messages to return" })
+  Limit?: number;
+
+  @IsOptional()
+  @IsNumber({ allowNaN: false }, { message: "The offset must be a number" })
+  @Min(0)
+  @ApiProperty({ description: "The offset of messages to return" })
+  Offset?: number;
+
+  @IsDateString()
+  @IsOptional()
+  @ApiProperty({
+    description: "The time the message was delivered",
+    required: false,
+    type: "string",
+    format: "date-time",
+  })
+  DeliveredAt?: Date;
+}

--- a/message-service/src/messages/entities/message.entity.ts
+++ b/message-service/src/messages/entities/message.entity.ts
@@ -9,6 +9,19 @@ import {
 } from "typeorm";
 import { Group } from "./group.entity";
 
+export enum MessageStatus {
+  Edited = "edited",
+  Deleted = "deleted",
+}
+
+export enum MessageType {
+  Text = "text",
+  Image = "image",
+  Video = "video",
+  Audio = "audio",
+  File = "file",
+}
+
 @Entity()
 export class Message {
   @PrimaryGeneratedColumn()
@@ -21,17 +34,14 @@ export class Message {
   SenderId: number;
 
   @Column({ type: "int", nullable: true })
-  ReceiverId: number;
-
-  @Column({ type: "int", nullable: true })
   GroupId: number;
 
-  @Column({ type: "enum", enum: ["edited", "deleted"], nullable: true })
+  @Column({ type: "enum", enum: MessageStatus, nullable: true })
   Status: string;
 
   @Column({
     type: "enum",
-    enum: ["text", "image", "video", "audio", "file"],
+    enum: MessageType,
     default: "text",
   })
   Type: string;

--- a/message-service/src/messages/services/messages/messages.service.ts
+++ b/message-service/src/messages/services/messages/messages.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { CreateMessageDto } from "src/messages/dtos/message.dto";
+import {
+  CreateMessageDto,
+  FilterMessagesDto,
+} from "src/messages/dtos/message.dto";
 
-import { Message } from "src/messages/entities/message.entity";
-import { Repository } from "typeorm";
+import { Message, MessageType } from "src/messages/entities/message.entity";
+import { Between, FindOptionsWhere, Repository } from "typeorm";
 
 @Injectable()
 export class MessagesService {
@@ -14,5 +17,50 @@ export class MessagesService {
   async createMessage(data: CreateMessageDto) {
     const message = this.messageRepository.create(data);
     return await this.messageRepository.save(message);
+  }
+
+  async findAll(params: FilterMessagesDto): Promise<Message[]> {
+    // Destruction of the params object
+    const { GroupId, Type, Limit, Offset, DeliveredAt } = params;
+
+    // Declare an object to store the where clause
+    const where: FindOptionsWhere<Message> = {};
+
+    // Validate that the end date is not before the start date
+    // Declare a variable to store the current date
+    const currentDate: Date = new Date();
+
+    // Validate that a GroupId was sent
+    if (!GroupId) {
+      throw new Error("A GroupId must be sent");
+    }
+
+    // Update the where clause with the GroupId
+    where.GroupId = GroupId;
+
+    // Validate that the Type is a valid MessageType
+    if (Type) {
+      if (!Object.values(MessageType).includes(Type)) {
+        throw new Error("The message type is not valid");
+      } else {
+        where.Type = Type;
+      }
+    }
+
+    if (DeliveredAt) {
+      if (new Date(DeliveredAt) > currentDate) {
+        throw new Error("The end date cannot be in the future");
+      } else {
+        // Update the where clause with the dates, and make it Between the start and end date
+        where.DeliveredAt = Between(DeliveredAt, currentDate);
+      }
+    }
+
+    // Return the found messages
+    return await this.messageRepository.find({
+      where,
+      take: Limit,
+      skip: Offset,
+    });
   }
 }


### PR DESCRIPTION
…essages, the service method to get messages by specified filters and updates to Entities and Dtos.

### Description

Please include a summary of the change and which issue is addressed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- First draft for loading initial messages.
- Dto and Entities update.
- Dto for FilterMessages given certain params.
- findAll method for getting all messages given a `GroupId` and optional `Type, Limit, Offset, DeliveredAt`
- Migrations can now be run locally because we now have a env.prod and a .env

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual Testing
- [ ] Unit test: jest
- [ ] e2e: Supertest

### How to use the feature
A GIF of the feature in action is useful here for larger features, otherwise a description suffices.
- Simply join a GroupId
- Send the event initialMessages specifying a required GroupId and optional parameters specified above.

### Prerequisites
Whether reviewers should add env variables (don't put them in here), run npm install, specific browser requirements, etc.

Please check the private repo for the environmental variables as it now contains a `.env` and a `.end.prod`

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have linked the relevant issue(s) to this PR
- [ ] All checks pass on CI/CD.
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules